### PR TITLE
Update initTorqueBalancing.m

### DIFF
--- a/controllers/torqueBalancing/initTorqueBalancing.m
+++ b/controllers/torqueBalancing/initTorqueBalancing.m
@@ -128,7 +128,7 @@ baseToWorldRotationPort  = ['/' WBT_modelName '/floatingBaseRotationMatrix:i'];
 run(strcat('app/robots/',getenv('YARP_ROBOT_NAME'),'/gains.m')); 
 addpath('./src/')
 addpath('../utilityMatlabFunctions/')
-[ConstraintsMatrix,bVectorConstraints]= constraints(forceFrictionCoefficient,numberOfPoints,torsionalFrictionCoefficient,gain.footSize,fZmin);
+
 
 robotSpecificReferences  = fullfile('app/robots',getenv('YARP_ROBOT_NAME'),'initRefGen.m');
 run(robotSpecificReferences);
@@ -152,6 +152,6 @@ elseif strcmpi(SM.SM_TYPE, 'WALKING')
     run(robotSpecificFSM);
 end
 
-
+[ConstraintsMatrix,bVectorConstraints]= constraints(forceFrictionCoefficient,numberOfPoints,torsionalFrictionCoefficient,gain.footSize,fZmin);
 
 


### PR DESCRIPTION
Constraints matrices used in QP are obtained from the foot size defined in "gains.m" and not from the TYPE specific init file.
